### PR TITLE
Add live currency exchange rate display

### DIFF
--- a/src/app/currency.service.ts
+++ b/src/app/currency.service.ts
@@ -1,16 +1,42 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
+import { ExchangeData } from './interfaces/exchange-data.interface';
 
 @Injectable({ providedIn: 'root' })
 export class CurrencyService {
   private currencyCodeSubject = new BehaviorSubject<string>('');
+  private currentRate = new BehaviorSubject(null);
+  private dailyRates = new BehaviorSubject(null);
+  private exchangeData = new BehaviorSubject<ExchangeData | null>(null);
+  private isLoading = new BehaviorSubject<boolean>(false);
   public currencyCode$ = this.currencyCodeSubject.asObservable();
+
+  currentRate$ = this.currentRate.asObservable();
+  dailyRates$ = this.dailyRates.asObservable();
+  exchangeData$ = this.exchangeData.asObservable();
+  isLoading$ = this.isLoading.asObservable();
+
+  updateCurrentRate(data: any) {
+    this.currentRate.next(data);
+  }
+
+  updateDailyRates(data: any) {
+    this.dailyRates.next(data);
+  }
+
+  updateExchangeData(data: ExchangeData) {
+    this.exchangeData.next(data);
+  }
 
   getCurrentCurrency(): string {
     return this.currencyCodeSubject.value;
   }
 
   setCurrencyCode(code: string) {
-    this.currencyCodeSubject.next(code);
+    this.currencyCodeSubject.next(code.toUpperCase());
+  }
+
+  setLoading(state: boolean) {
+    this.isLoading.next(state);
   }
 }

--- a/src/app/exchange-rate/exchange-rate.component.html
+++ b/src/app/exchange-rate/exchange-rate.component.html
@@ -1,12 +1,22 @@
-<div class="exchange-container">
-  <div class="exchange-rate">
-    <p class="title">Exchange rate now</p>
-    <p class="subtitle">XX/XX/XXXX - 20h49</p>
+<ng-container
+  *ngIf="(isLoading$ | async) === false && (exchangeData$ | async) as data"
+>
+  <div class="exchange-container">
+    <div class="exchange-rate">
+      <p class="title">Exchange rate now</p>
+      <p class="subtitle">
+        {{
+          (exchangeData$ | async)?.lastUpdatedAt | date : "dd/MM/yyyy - HH'h'mm"
+        }}
+      </p>
+    </div>
+    <div>
+      <p class="currency-text">{{ currencyCode$ | async }}/BRL</p>
+    </div>
   </div>
-  <div>
-    <p class="currency-text">USD/BRL</p>
+  <div class="currency-container">
+    <p class="currency-text">
+      R$ {{ ((exchangeData$ | async)?.rate ?? 0).toFixed(2).replace(".", ",") }}
+    </p>
   </div>
-</div>
-<div class="currency-container">
-  <p class="currency-text">R$ 5,00</p>
-</div>
+</ng-container>

--- a/src/app/exchange-rate/exchange-rate.component.ts
+++ b/src/app/exchange-rate/exchange-rate.component.ts
@@ -1,9 +1,19 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CurrencyService } from '../currency.service';
+import { AsyncPipe, DatePipe } from '@angular/common';
 
 @Component({
   selector: 'app-exchange-rate',
-  imports: [],
+  imports: [CommonModule, AsyncPipe, DatePipe],
   templateUrl: './exchange-rate.component.html',
   styleUrl: './exchange-rate.component.css',
+  providers: [DatePipe],
 })
-export class ExchangeRateComponent {}
+export class ExchangeRateComponent {
+  private currencyService = inject(CurrencyService);
+
+  exchangeData$ = this.currencyService.exchangeData$;
+  currencyCode$ = this.currencyService.currencyCode$;
+  isLoading$ = this.currencyService.isLoading$;
+}

--- a/src/app/interfaces/exchange-data.interface.ts
+++ b/src/app/interfaces/exchange-data.interface.ts
@@ -1,0 +1,5 @@
+export interface ExchangeData {
+  rate: number;
+  lastUpdatedAt: string;
+  fromSymbol: string;
+}

--- a/src/app/primary-button/primary-button.component.ts
+++ b/src/app/primary-button/primary-button.component.ts
@@ -13,6 +13,24 @@ export class PrimaryButtonComponent {
     private currencyService: CurrencyService
   ) {}
 
+  getData(currencyCode: string) {
+    this.apiService.getCurrentExchangeRate(currencyCode).subscribe({
+      next: (response) => {
+        console.log('Current Rate:', response);
+        this.currencyService.updateCurrentRate(response);
+      },
+      error: (error) => console.error('Error:', error),
+    });
+
+    this.apiService.getDailyExchangeRate(currencyCode).subscribe({
+      next: (response) => {
+        console.log('Daily Rates:', response);
+        this.currencyService.updateDailyRates(response);
+      },
+      error: (error) => console.error('Error:', error),
+    });
+  }
+
   submitCurrency() {
     const currencyCode = this.currencyService.getCurrentCurrency();
 
@@ -21,10 +39,21 @@ export class PrimaryButtonComponent {
       return;
     }
 
+    this.currencyService.setLoading(true);
+
     this.apiService.getCurrentExchangeRate(currencyCode).subscribe({
-      next: (response) =>
-        console.log('Response from getCurrencyExchangeRate:', response),
-      error: (error) => console.error('Error:', error),
+      next: (response) => {
+        this.currencyService.updateExchangeData({
+          rate: response.exchangeRate,
+          lastUpdatedAt: new Date().toISOString(),
+          fromSymbol: `${currencyCode}/BRL`,
+        });
+        this.currencyService.setLoading(false);
+      },
+      error: (error) => {
+        console.error('Error:', error);
+        this.currencyService.setLoading(false);
+      },
     });
 
     this.apiService.getDailyExchangeRate(currencyCode).subscribe({


### PR DESCRIPTION
- Shows real exchange rates after clicking the button
- Displays loading spinner while waiting for API
-Formats numbers correctly (R$ 5,00)
- Shows currency pair (USD/BRL)
- Displays timestamp (07/05/2025 - 23h56)